### PR TITLE
Idv 732 add pyqtgraph as backend to iplotlib

### DIFF
--- a/default_mint_env
+++ b/default_mint_env
@@ -8,6 +8,7 @@ IPLOT_SOURCES_CONFIG=/etc/opt/codac/mint/mydatasources.cfg
 IPLOT_LOG_LIMIT=10
 MINT_GET_EXTRE=false
 IPLOT_CANVAS_CONFIG=/etc/opt/codac/mint/canvas_default_properties.json
+IPLOT_PYQTGRAPH_OPENGL=true
 UDA_MAX_SOCKET_DELAY=0
 UDA_MAX_SOCKET_ATTEMPTS=0
 

--- a/mint/app/entryPoint.py
+++ b/mint/app/entryPoint.py
@@ -68,7 +68,7 @@ def run_app(q_app: QApplication, args=None):
     #########################################################################
     # 3. Prepare model for data range
     t_now = datetime.utcnow().isoformat(timespec='seconds')
-    t_now_delta_seven_d = datetime.utcnow() - timedelta(days=7)
+    t_now_delta_seven_d = datetime.utcnow() - timedelta(minutes=5)
 
     time_model = {
         "range": {

--- a/mint/gui/mtDataRangeSelector.py
+++ b/mint/gui/mtDataRangeSelector.py
@@ -95,7 +95,7 @@ class MTDataRangeSelector(QWidget):
         self.stack.setCurrentIndex(page_id)
         self.modeChanged.emit()
         # Emit cancelRefresh if we are leaving relative mode
-        if self.accessModes[self.stack.currentIndex()].mode == MTGenericAccessMode.RELATIVE_TIME:
+        if self.accessModes[self.stack.currentIndex()].mode != MTGenericAccessMode.RELATIVE_TIME:
             self.cancelRefresh.emit()
             logger.info("Canvas auto-refresh cancelled (left relative mode)")
 

--- a/mint/gui/mtDataRangeSelector.py
+++ b/mint/gui/mtDataRangeSelector.py
@@ -89,7 +89,7 @@ class MTDataRangeSelector(QWidget):
         item.from_dict(input_dict)
 
         # Always clear the pulse reference in Time Range mode
-        self.accessModes[0].clear_pulse()
+        self.accessModes[0].pulseUsed.setText("")
 
     def select_page(self, page_id: int):
         self.stack.setCurrentIndex(page_id)

--- a/mint/gui/mtMainWindow.py
+++ b/mint/gui/mtMainWindow.py
@@ -693,7 +693,7 @@ class MTMainWindow(ShiftHandlerMixin, IplotQtMainWindow):
                     valid = generateData(logfile=None, conn=conn, csvfile=filename, formatType=export_format,
                                          startTime=ts_str, endTime=te_str, outputFolder=new_path, chunkS=chunks)
                     if valid:
-                        logger.info(f"Export successful for data source: {ds_name} in format: {export_format}")
+                        logger.info(f"Export successful for data source: {ds_name} (format: {export_format} | Path: {new_path}")
                     else:
                         logger.info(f"Export failed for data source: {ds_name}")
             else:
@@ -708,7 +708,7 @@ class MTMainWindow(ShiftHandlerMixin, IplotQtMainWindow):
                 valid = generateData(logfile=None, conn=conn, csvfile=filename, formatType=export_format,
                                      startTime=ts_str, endTime=te_str, outputFolder=new_path, chunkS=chunks)
                 if valid:
-                    logger.info(f"Export successful for data source: {ds_name} in format: {export_format}")
+                    logger.info(f"Export successful for data source: {ds_name} (format: {export_format} | Path: {new_path}")
                 else:
                     logger.info(f"Export failed for data source: {ds_name}")
 

--- a/mint/models/accessModes/mtAbsoluteTime.py
+++ b/mint/models/accessModes/mtAbsoluteTime.py
@@ -99,7 +99,7 @@ class MTAbsoluteTime(MTGenericAccessMode):
         fromTimeLayout.addWidget(QLabel(".", parent=self.form))
         fromTimeLayout.addWidget(self.fromTimeNs)
         fromTimeLayout.addWidget(QLabel("ns", parent=self.form))
-        fromTimeLayout.setAlignment(Qt.AlignLeft)
+        fromTimeLayout.setAlignment(Qt.AlignmentFlag.AlignLeft)
 
         # Create layout for the "To time" row
         toTimeLayout = QHBoxLayout()
@@ -107,7 +107,7 @@ class MTAbsoluteTime(MTGenericAccessMode):
         toTimeLayout.addWidget(QLabel(".", parent=self.form))
         toTimeLayout.addWidget(self.toTimeNs)
         toTimeLayout.addWidget(QLabel("ns", parent=self.form))
-        toTimeLayout.setAlignment(Qt.AlignLeft)  # Align items to the left
+        toTimeLayout.setAlignment(Qt.AlignmentFlag.AlignLeft)  # Align items to the left
 
         # Add the rows to the form layout
         self.form.layout().addRow(QLabel("From time", parent=self.form), fromTimeLayout)
@@ -214,12 +214,13 @@ class MTAbsoluteTime(MTGenericAccessMode):
 
         # Set the values in the UI
         # Save current time values before overwriting so Clear can restore them
-        self._saved_time_before_pulse = {
-            'from_time': QDateTime(self.fromTime.dateTime()),
-            'to_time': QDateTime(self.toTime.dateTime()),
-            'from_ns': self.fromTimeNs.text(),
-            'to_ns': self.toTimeNs.text()
-        }
+        if self._saved_time_before_pulse is None:
+            self._saved_time_before_pulse = {
+                'from_time': QDateTime(self.fromTime.dateTime()),
+                'to_time': QDateTime(self.toTime.dateTime()),
+                'from_ns': self.fromTimeNs.text(),
+                'to_ns': self.toTimeNs.text()
+            }
 
         self.model.setStringList([
             qdt_from.toString(MTAbsoluteTime.TIME_FORMAT),

--- a/mint/models/mtSignalsModel.py
+++ b/mint/models/mtSignalsModel.py
@@ -314,7 +314,7 @@ class MTSignalsModel(QAbstractItemModel):
         df_fails = pd.DataFrame(data=0, index=range(df.shape[0]), columns=self._table_fails.columns)
 
         # Check if last row is empty
-        if self._table.empty or self._table.iloc[-1:, 1:-5].any(axis=1).bool():
+        if self._table.empty or self._table.iloc[-1:, 1:-5].any(axis=1).item():
             self._table = pd.concat([self._table, df], ignore_index=True).fillna('')
             self.insertRows(len(self._table), 1, QModelIndex())
             self._table_fails = pd.concat([self._table_fails, df_fails], ignore_index=True)


### PR DESCRIPTION
Fixed the following issues:
- [Add environment variable to configure PyQtGraph OpenGL usage](https://github.com/iplot-viz/mint/issues/63)
- [plot XY with slider zoom and slider not working as expected](https://github.com/iplot-viz/mint/issues/60)
- [relative tab and then switch to other tab still trigger a rebuilt of the canvas](https://github.com/iplot-viz/mint/issues/58)
- [new version of pandas not compatible with mint](https://github.com/iplot-viz/mint/issues/41)
- [export data does not work with pulse](https://github.com/iplot-viz/mint/issues/36)
- [pyqtgraph labels issue](https://github.com/iplot-viz/mint/issues/31)
- [zoom and pyqtgraph](https://github.com/iplot-viz/mint/issues/25)
- [Pulse and absolute time](https://github.com/iplot-viz/mint/issues/14)