### PR TITLE
Make MINT use its own canvas properties JSON

### DIFF
--- a/mint/__main__.py
+++ b/mint/__main__.py
@@ -20,6 +20,11 @@ def load_env(fpath):
 
 
 def main():
+    if 'IPLOT_CANVAS_CONFIG' not in os.environ:
+        from importlib import resources
+        bundled = resources.files('mint.data').joinpath('canvas_properties', 'default_properties.json')
+        os.environ['IPLOT_CANVAS_CONFIG'] = str(bundled)
+
     if os.environ.get('MINT_XK_CONFIG') is not None and os.path.isfile(os.environ.get('MINT_XK_CONFIG')):
         logger.info("Found an environment XK_CONFIG file for MINT")
         load_env(os.environ.get('MINT_XK_CONFIG'))

--- a/mint/data/canvas_properties/default_properties.json
+++ b/mint/data/canvas_properties/default_properties.json
@@ -1,11 +1,12 @@
 {
   "title": null,
   "font_size": 8,
-  "shared_x_axis": false,
+  "shared_x_axis": true,
   "max_diff": 1,
   "round_hour": false,
   "log_scale": false,
   "grid": true,
+  "grid_spacing_label": false,
   "ticks_position": false,
   "tick_number": 7,
   "background_color": "#FFFFFF",


### PR DESCRIPTION
Two small changes, both in MINT, nothing touched in iplotlib:

- `mint/__main__.py` now sets `IPLOT_CANVAS_CONFIG` at the top of `main()` to point at MINT's bundled JSON, but only if no override is already in the environment. So `default_mint_env` (the CODAC deployment path) and any `MINT_XK_CONFIG` overrides still win — production behaviour is unchanged.

- `mint/data/canvas_properties/default_properties.json` now has `shared_x_axis: true` (was false) and the previously missing `grid_spacing_label: false`. `autoscale` was already false.

Verified end-to-end: in dev MINT loads its own JSON, and the override path keeps winning when set.