### PR TITLE
fix(pulse): #117 preserve user-edited time range on Clear

### DIFF
--- a/mint/models/accessModes/mtAbsoluteTime.py
+++ b/mint/models/accessModes/mtAbsoluteTime.py
@@ -136,26 +136,34 @@ class MTAbsoluteTime(MTGenericAccessMode):
         super().from_dict(contents)
 
     def clear_pulse(self):
-        """Clear the pulse reference field and restore the time fields to their pre-pulse state."""
+        """Clear the pulse reference field and restore pre-pulse times only
+        if the user has not modified them relative to the selected pulse."""
         self.pulseUsed.setText("")
+        if self._saved_time_before_pulse is None:
+            return
+        saved = self._saved_time_before_pulse
+        self._saved_time_before_pulse = None
 
-        if self._saved_time_before_pulse is not None:
-            # Restore the time values that were present before the pulse was selected
-            saved = self._saved_time_before_pulse
-            self.fromTime.setDateTime(saved['from_time'])
-            self.toTime.setDateTime(saved['to_time'])
-            self.fromTimeNs.setText(saved['from_ns'])
-            self.toTimeNs.setText(saved['to_ns'])
-            # Update the underlying model
-            self.model.setStringList([
-                saved['from_time'].toString(MTAbsoluteTime.TIME_FORMAT) if not saved['from_time'].isNull() else '',
-                saved['to_time'].toString(MTAbsoluteTime.TIME_FORMAT) if not saved['to_time'].isNull() else '',
-                saved['from_ns'],
-                saved['to_ns']
-            ])
-            self.mapper.toFirst()
-            self._saved_time_before_pulse = None
-        # If no saved state, just clear the pulse text (times remain as they are)
+        user_modified = (
+            self.fromTime.dateTime() != saved['pulse_from_time']
+            or self.toTime.dateTime() != saved['pulse_to_time']
+            or self.fromTimeNs.text() != saved['pulse_from_ns']
+            or self.toTimeNs.text() != saved['pulse_to_ns']
+        )
+        if user_modified:
+            return
+
+        self.fromTime.setDateTime(saved['from_time'])
+        self.toTime.setDateTime(saved['to_time'])
+        self.fromTimeNs.setText(saved['from_ns'])
+        self.toTimeNs.setText(saved['to_ns'])
+        self.model.setStringList([
+            saved['from_time'].toString(MTAbsoluteTime.TIME_FORMAT) if not saved['from_time'].isNull() else '',
+            saved['to_time'].toString(MTAbsoluteTime.TIME_FORMAT) if not saved['to_time'].isNull() else '',
+            saved['from_ns'],
+            saved['to_ns']
+        ])
+        self.mapper.toFirst()
 
     def handle_time_validation(self):
         if self.sender() == self.fromTimeNs:
@@ -214,12 +222,17 @@ class MTAbsoluteTime(MTGenericAccessMode):
 
         # Set the values in the UI
         # Save current time values before overwriting so Clear can restore them
+        # and the pulse values so Clear can tell whether the user edited them.
         if self._saved_time_before_pulse is None:
             self._saved_time_before_pulse = {
                 'from_time': QDateTime(self.fromTime.dateTime()),
                 'to_time': QDateTime(self.toTime.dateTime()),
                 'from_ns': self.fromTimeNs.text(),
-                'to_ns': self.toTimeNs.text()
+                'to_ns': self.toTimeNs.text(),
+                'pulse_from_time': QDateTime(qdt_from),
+                'pulse_to_time': QDateTime(qdt_to),
+                'pulse_from_ns': ns_from,
+                'pulse_to_ns': ns_to,
             }
 
         self.model.setStringList([

--- a/mint/tests/test_08_access_modes.py
+++ b/mint/tests/test_08_access_modes.py
@@ -12,6 +12,8 @@ but the serialisation behaviour is testable headlessly.
 
 import unittest
 
+from PySide6.QtCore import QDateTime
+
 from iplotDataAccess.appDataAccess import AppDataAccess
 
 from mint.models.accessModes.mtAbsoluteTime import MTAbsoluteTime
@@ -77,6 +79,79 @@ class AbsoluteTimeTest(unittest.TestCase):
         props = mode.properties()
         self.assertEqual(props['ts_ns_start'], '000000000')
         self.assertEqual(props['ts_ns_end'], '000000000')
+
+
+class AbsoluteTimeClearPulseTest(unittest.TestCase):
+    """Clear-pulse keeps user-edited timestamps; only resets when the
+    fields still match the pulse that originally populated them."""
+
+    FMT = MTAbsoluteTime.TIME_FORMAT
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.app = ensure_qapp()
+        _ensure_data_access()
+
+    def _seed_pulse_snapshot(self, mode):
+        pre_from = QDateTime.fromString('2024-01-15T10:00:00', self.FMT)
+        pre_to = QDateTime.fromString('2024-01-15T11:00:00', self.FMT)
+        pulse_from = QDateTime.fromString('2024-01-15T12:00:00', self.FMT)
+        pulse_to = QDateTime.fromString('2024-01-15T13:00:00', self.FMT)
+        mode.fromTime.setDateTime(pulse_from)
+        mode.toTime.setDateTime(pulse_to)
+        mode.fromTimeNs.setText('000000000')
+        mode.toTimeNs.setText('000000000')
+        mode.pulseUsed.setText('ITER:test/1')
+        mode._saved_time_before_pulse = {
+            'from_time': pre_from,
+            'to_time': pre_to,
+            'from_ns': '111111111',
+            'to_ns': '222222222',
+            'pulse_from_time': pulse_from,
+            'pulse_to_time': pulse_to,
+            'pulse_from_ns': '000000000',
+            'pulse_to_ns': '000000000',
+        }
+        return pre_from, pre_to, pulse_from, pulse_to
+
+    def test_clear_restores_pre_pulse_when_user_did_not_edit(self):
+        mode = MTAbsoluteTime({})
+        pre_from, pre_to, _, _ = self._seed_pulse_snapshot(mode)
+        mode.clear_pulse()
+        self.assertEqual(mode.pulseUsed.text(), '')
+        self.assertEqual(mode.fromTime.dateTime(), pre_from)
+        self.assertEqual(mode.toTime.dateTime(), pre_to)
+        self.assertEqual(mode.fromTimeNs.text(), '111111111')
+        self.assertEqual(mode.toTimeNs.text(), '222222222')
+        self.assertIsNone(mode._saved_time_before_pulse)
+
+    def test_clear_preserves_user_edit_to_from_time(self):
+        mode = MTAbsoluteTime({})
+        _, _, _, pulse_to = self._seed_pulse_snapshot(mode)
+        edited_from = QDateTime.fromString('2024-01-15T12:30:00', self.FMT)
+        mode.fromTime.setDateTime(edited_from)
+        mode.clear_pulse()
+        self.assertEqual(mode.pulseUsed.text(), '')
+        self.assertEqual(mode.fromTime.dateTime(), edited_from)
+        self.assertEqual(mode.toTime.dateTime(), pulse_to)
+        self.assertIsNone(mode._saved_time_before_pulse)
+
+    def test_clear_preserves_user_edit_to_ns_field(self):
+        mode = MTAbsoluteTime({})
+        self._seed_pulse_snapshot(mode)
+        mode.fromTimeNs.setText('500000000')
+        mode.clear_pulse()
+        self.assertEqual(mode.fromTimeNs.text(), '500000000')
+        self.assertIsNone(mode._saved_time_before_pulse)
+
+    def test_clear_without_pulse_snapshot_is_noop_on_times(self):
+        mode = MTAbsoluteTime({})
+        free_from = QDateTime.fromString('2024-02-01T08:00:00', self.FMT)
+        mode.fromTime.setDateTime(free_from)
+        mode.pulseUsed.setText('stray-label')
+        mode.clear_pulse()
+        self.assertEqual(mode.pulseUsed.text(), '')
+        self.assertEqual(mode.fromTime.dateTime(), free_from)
 
 
 class PulseIdTest(unittest.TestCase):


### PR DESCRIPTION
clear_pulse compares current time fields against the pulse values captured in fill_from_pulse and only restores the pre-pulse snapshot when they still match — any user edit after selecting the pulse is kept intact, only the pulse reference is removed.