### PR TITLE
Add View > Appearance menu for runtime style and theme selection

### DIFF
--- a/mint/app/createApp.py
+++ b/mint/app/createApp.py
@@ -41,4 +41,8 @@ def create_app(argv=None) -> (QApplication, Namespace):
     qApp.setOrganizationDomain("www.iter.org")
     qApp.setOrganizationName("ITER")
 
+    # must come after the organization/application names are set: QSettings depends on them
+    from mint.gui.mtAppearance import restore_appearance
+    restore_appearance()
+
     return qApp, args

--- a/mint/gui/mtAppearance.py
+++ b/mint/gui/mtAppearance.py
@@ -1,9 +1,12 @@
-# Description: Runtime selection of the application look (widget style, color scheme),
+# Description: Runtime selection of the application look (widget style, style-sheet theme),
 #              persisted across sessions with QSettings.
 # Author: Simon Pinches
 
-from PySide6.QtCore import QSettings, Qt
+import pkgutil
+import typing
+
 from PySide6.QtGui import QAction, QActionGroup
+from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QApplication, QMenu, QStyleFactory
 
 from iplotLogging import setupLogger as setupLog
@@ -11,18 +14,11 @@ from iplotLogging import setupLogger as setupLog
 logger = setupLog.get_logger(__name__)
 
 STYLE_KEY = 'appearance/style'
-COLOR_SCHEME_KEY = 'appearance/colorScheme'
+THEME_KEY = 'appearance/theme'
 
-COLOR_SCHEMES = {
-    'system': Qt.ColorScheme.Unknown,
-    'light': Qt.ColorScheme.Light,
-    'dark': Qt.ColorScheme.Dark,
-}
-
-
-def color_schemes_supported() -> bool:
-    # QStyleHints.setColorScheme() needs Qt >= 6.8; on older Qt the menu entry is omitted
-    return hasattr(QApplication.styleHints(), 'setColorScheme')
+# style-sheet themes shipped in mint/gui/themes/<name>.qss
+THEME_NONE = 'None'
+THEMES = ('Dark', 'Light')
 
 
 def apply_style(name: str):
@@ -33,13 +29,26 @@ def apply_style(name: str):
     QSettings().setValue(STYLE_KEY, name)
 
 
-def apply_color_scheme(name: str):
-    """Switch the color scheme (system/light/dark) at runtime and persist the choice."""
-    if name not in COLOR_SCHEMES or not color_schemes_supported():
-        logger.warning(f"Unsupported color scheme: {name}")
+def _load_theme(name: str) -> typing.Optional[str]:
+    try:
+        data = pkgutil.get_data('mint.gui', f'themes/{name.lower()}.qss')
+    except (FileNotFoundError, OSError):
+        data = None
+    return data.decode('utf-8') if data is not None else None
+
+
+def apply_theme(name: str):
+    """Switch the application style-sheet theme at runtime and persist the choice."""
+    if name == THEME_NONE:
+        QApplication.instance().setStyleSheet('')
+        QSettings().setValue(THEME_KEY, name)
         return
-    QApplication.styleHints().setColorScheme(COLOR_SCHEMES[name])
-    QSettings().setValue(COLOR_SCHEME_KEY, name)
+    qss = _load_theme(name)
+    if qss is None:
+        logger.warning(f"Unknown style-sheet theme: {name}")
+        return
+    QApplication.instance().setStyleSheet(qss)
+    QSettings().setValue(THEME_KEY, name)
 
 
 def restore_appearance():
@@ -48,13 +57,17 @@ def restore_appearance():
     style = settings.value(STYLE_KEY)
     if style and QApplication.setStyle(style) is None:
         logger.warning(f"Persisted widget style is not available: {style}")
-    scheme = settings.value(COLOR_SCHEME_KEY)
-    if scheme in COLOR_SCHEMES and color_schemes_supported():
-        QApplication.styleHints().setColorScheme(COLOR_SCHEMES[scheme])
+    theme = settings.value(THEME_KEY)
+    if theme and theme != THEME_NONE:
+        qss = _load_theme(theme)
+        if qss is None:
+            logger.warning(f"Persisted style-sheet theme is not available: {theme}")
+        else:
+            QApplication.instance().setStyleSheet(qss)
 
 
 class MTAppearanceMenu(QMenu):
-    """An 'Appearance' menu offering the built-in widget styles and color schemes."""
+    """An 'Appearance' menu offering the built-in widget styles and style-sheet themes."""
 
     def __init__(self, parent=None):
         super().__init__("&Appearance", parent)
@@ -73,15 +86,14 @@ class MTAppearanceMenu(QMenu):
             style_group.addAction(action)
             self._style_menu.addAction(action)
 
-        if color_schemes_supported():
-            self._scheme_menu = QMenu("&Color scheme", self)
-            self.addMenu(self._scheme_menu)
-            scheme_group = QActionGroup(self)
-            current_scheme = QSettings().value(COLOR_SCHEME_KEY, 'system')
-            for name in COLOR_SCHEMES:
-                action = QAction(name.capitalize(), self)
-                action.setCheckable(True)
-                action.setChecked(name == current_scheme)
-                action.triggered.connect(lambda checked=False, n=name: apply_color_scheme(n))
-                scheme_group.addAction(action)
-                self._scheme_menu.addAction(action)
+        self._theme_menu = QMenu("&Theme", self)
+        self.addMenu(self._theme_menu)
+        theme_group = QActionGroup(self)
+        current_theme = QSettings().value(THEME_KEY, THEME_NONE)
+        for name in (THEME_NONE,) + THEMES:
+            action = QAction(name, self)
+            action.setCheckable(True)
+            action.setChecked(name == current_theme)
+            action.triggered.connect(lambda checked=False, n=name: apply_theme(n))
+            theme_group.addAction(action)
+            self._theme_menu.addAction(action)

--- a/mint/gui/mtAppearance.py
+++ b/mint/gui/mtAppearance.py
@@ -1,0 +1,87 @@
+# Description: Runtime selection of the application look (widget style, color scheme),
+#              persisted across sessions with QSettings.
+# Author: Simon Pinches
+
+from PySide6.QtCore import QSettings, Qt
+from PySide6.QtGui import QAction, QActionGroup
+from PySide6.QtWidgets import QApplication, QMenu, QStyleFactory
+
+from iplotLogging import setupLogger as setupLog
+
+logger = setupLog.get_logger(__name__)
+
+STYLE_KEY = 'appearance/style'
+COLOR_SCHEME_KEY = 'appearance/colorScheme'
+
+COLOR_SCHEMES = {
+    'system': Qt.ColorScheme.Unknown,
+    'light': Qt.ColorScheme.Light,
+    'dark': Qt.ColorScheme.Dark,
+}
+
+
+def color_schemes_supported() -> bool:
+    # QStyleHints.setColorScheme() needs Qt >= 6.8; on older Qt the menu entry is omitted
+    return hasattr(QApplication.styleHints(), 'setColorScheme')
+
+
+def apply_style(name: str):
+    """Switch the widget style at runtime and persist the choice."""
+    if QApplication.setStyle(name) is None:
+        logger.warning(f"Unknown widget style: {name}")
+        return
+    QSettings().setValue(STYLE_KEY, name)
+
+
+def apply_color_scheme(name: str):
+    """Switch the color scheme (system/light/dark) at runtime and persist the choice."""
+    if name not in COLOR_SCHEMES or not color_schemes_supported():
+        logger.warning(f"Unsupported color scheme: {name}")
+        return
+    QApplication.styleHints().setColorScheme(COLOR_SCHEMES[name])
+    QSettings().setValue(COLOR_SCHEME_KEY, name)
+
+
+def restore_appearance():
+    """Re-apply the persisted appearance. Call once, right after the QApplication is created."""
+    settings = QSettings()
+    style = settings.value(STYLE_KEY)
+    if style and QApplication.setStyle(style) is None:
+        logger.warning(f"Persisted widget style is not available: {style}")
+    scheme = settings.value(COLOR_SCHEME_KEY)
+    if scheme in COLOR_SCHEMES and color_schemes_supported():
+        QApplication.styleHints().setColorScheme(COLOR_SCHEMES[scheme])
+
+
+class MTAppearanceMenu(QMenu):
+    """An 'Appearance' menu offering the built-in widget styles and color schemes."""
+
+    def __init__(self, parent=None):
+        super().__init__("&Appearance", parent)
+
+        # submenus are created with an explicit parent and kept as attributes: the menus returned
+        # by QMenu.addMenu(str) are owned by the Python wrapper and get garbage-collected
+        self._style_menu = QMenu("&Style", self)
+        self.addMenu(self._style_menu)
+        style_group = QActionGroup(self)
+        current_style = QApplication.style().objectName().lower()
+        for name in QStyleFactory.keys():
+            action = QAction(name, self)
+            action.setCheckable(True)
+            action.setChecked(name.lower() == current_style)
+            action.triggered.connect(lambda checked=False, n=name: apply_style(n))
+            style_group.addAction(action)
+            self._style_menu.addAction(action)
+
+        if color_schemes_supported():
+            self._scheme_menu = QMenu("&Color scheme", self)
+            self.addMenu(self._scheme_menu)
+            scheme_group = QActionGroup(self)
+            current_scheme = QSettings().value(COLOR_SCHEME_KEY, 'system')
+            for name in COLOR_SCHEMES:
+                action = QAction(name.capitalize(), self)
+                action.setCheckable(True)
+                action.setChecked(name == current_scheme)
+                action.triggered.connect(lambda checked=False, n=name: apply_color_scheme(n))
+                scheme_group.addAction(action)
+                self._scheme_menu.addAction(action)

--- a/mint/gui/mtAppearance.py
+++ b/mint/gui/mtAppearance.py
@@ -61,7 +61,9 @@ def restore_appearance():
     if theme and theme != THEME_NONE:
         qss = _load_theme(theme)
         if qss is None:
-            logger.warning(f"Persisted style-sheet theme is not available: {theme}")
+            # self-heal legacy/renamed theme names so settings and menu state stay consistent
+            logger.warning(f"Persisted style-sheet theme is not available, resetting it: {theme}")
+            settings.setValue(THEME_KEY, THEME_NONE)
         else:
             QApplication.instance().setStyleSheet(qss)
 
@@ -77,11 +79,13 @@ class MTAppearanceMenu(QMenu):
         self._style_menu = QMenu("&Style", self)
         self.addMenu(self._style_menu)
         style_group = QActionGroup(self)
-        current_style = QApplication.style().objectName().lower()
+        # when a style-sheet theme is active QApplication.style() is an anonymous
+        # QStyleSheetStyle wrapper, so prefer the persisted choice over its objectName
+        current_style = QSettings().value(STYLE_KEY, QApplication.style().objectName())
         for name in QStyleFactory.keys():
             action = QAction(name, self)
             action.setCheckable(True)
-            action.setChecked(name.lower() == current_style)
+            action.setChecked(name.lower() == current_style.lower())
             action.triggered.connect(lambda checked=False, n=name: apply_style(n))
             style_group.addAction(action)
             self._style_menu.addAction(action)
@@ -90,6 +94,9 @@ class MTAppearanceMenu(QMenu):
         self.addMenu(self._theme_menu)
         theme_group = QActionGroup(self)
         current_theme = QSettings().value(THEME_KEY, THEME_NONE)
+        if current_theme not in (THEME_NONE,) + THEMES:
+            # legacy/unknown persisted value: nothing would be applied, so show 'None' as checked
+            current_theme = THEME_NONE
         for name in (THEME_NONE,) + THEMES:
             action = QAction(name, self)
             action.setCheckable(True)

--- a/mint/gui/mtAppearance.py
+++ b/mint/gui/mtAppearance.py
@@ -56,7 +56,9 @@ def restore_appearance():
     settings = QSettings()
     style = settings.value(STYLE_KEY)
     if style and QApplication.setStyle(style) is None:
-        logger.warning(f"Persisted widget style is not available: {style}")
+        # self-heal legacy/renamed style names so settings and menu state stay consistent
+        logger.warning(f"Persisted widget style is not available, resetting it: {style}")
+        settings.remove(STYLE_KEY)
     theme = settings.value(THEME_KEY)
     if theme and theme != THEME_NONE:
         qss = _load_theme(theme)
@@ -80,8 +82,11 @@ class MTAppearanceMenu(QMenu):
         self.addMenu(self._style_menu)
         style_group = QActionGroup(self)
         # when a style-sheet theme is active QApplication.style() is an anonymous
-        # QStyleSheetStyle wrapper, so prefer the persisted choice over its objectName
-        current_style = QSettings().value(STYLE_KEY, QApplication.style().objectName())
+        # QStyleSheetStyle wrapper, so prefer the persisted choice over its objectName;
+        # a legacy/unknown persisted name falls back to the live style
+        current_style = QSettings().value(STYLE_KEY, '') or QApplication.style().objectName()
+        if current_style.lower() not in (k.lower() for k in QStyleFactory.keys()):
+            current_style = QApplication.style().objectName()
         for name in QStyleFactory.keys():
             action = QAction(name, self)
             action.setCheckable(True)

--- a/mint/gui/mtMainWindow.py
+++ b/mint/gui/mtMainWindow.py
@@ -33,6 +33,7 @@ from iplotlib.qt.gui.iplotQtMainWindow import IplotQtMainWindow
 
 from mint.gui.contextHelp import HELP_ANCHOR_PROPERTY, trigger_context_help
 from mint.gui.mtAbout import MTAbout
+from mint.gui.mtAppearance import MTAppearanceMenu
 from mint.gui.mtDataRangeSelector import MTDataRangeSelector
 from mint.gui.mtErrorCatalog import ErrorCatalog
 from mint.gui.mtMemoryMonitor import MTMemoryMonitor
@@ -151,7 +152,9 @@ class MTMainWindow(ShiftHandlerMixin, IplotQtMainWindow):
             self._on_rows_about_to_be_removed)
 
         file_menu = self.menuBar().addMenu("&File")
+        view_menu = self.menuBar().addMenu("&View")
         help_menu = self.menuBar().addMenu("&Help")
+        view_menu.addMenu(MTAppearanceMenu(self.menuBar()))
 
         exit_action = QAction("Exit", self.menuBar())
         exit_action.setShortcuts(QKeySequence.StandardKey.Quit)

--- a/mint/gui/themes/dark.qss
+++ b/mint/gui/themes/dark.qss
@@ -1,0 +1,245 @@
+/* MINT dark theme
+ * A flat, self-contained dark look, independent of the desktop theme and of
+ * which Qt style plugins are installed on the host.
+ */
+
+QWidget {
+    background-color: #2b2d31;
+    color: #e6e8eb;
+    selection-background-color: #2f6fad;
+    selection-color: #ffffff;
+}
+
+QWidget:disabled {
+    color: #797d85;
+}
+
+/* --- text inputs ------------------------------------------------------- */
+
+QLineEdit, QTextEdit, QPlainTextEdit, QSpinBox, QDoubleSpinBox,
+QDateEdit, QTimeEdit, QDateTimeEdit, QComboBox {
+    background-color: #232428;
+    border: 1px solid #1b1c1f;
+    border-radius: 3px;
+    padding: 2px 4px;
+}
+
+QLineEdit:focus, QTextEdit:focus, QPlainTextEdit:focus, QSpinBox:focus,
+QDoubleSpinBox:focus, QDateEdit:focus, QTimeEdit:focus, QDateTimeEdit:focus,
+QComboBox:focus {
+    border: 1px solid #2f6fad;
+}
+
+QComboBox::drop-down {
+    border: none;
+    width: 18px;
+}
+
+QComboBox QAbstractItemView {
+    background-color: #232428;
+    border: 1px solid #1b1c1f;
+}
+
+/* --- buttons ----------------------------------------------------------- */
+
+QPushButton, QToolButton {
+    background-color: #3a3d42;
+    border: 1px solid #1b1c1f;
+    border-radius: 3px;
+    padding: 3px 10px;
+}
+
+QToolButton {
+    padding: 3px;
+}
+
+QPushButton:hover, QToolButton:hover {
+    background-color: #44484f;
+}
+
+QPushButton:pressed, QToolButton:pressed, QToolButton:checked {
+    background-color: #2a2c30;
+}
+
+QPushButton:disabled, QToolButton:disabled {
+    background-color: #2f3136;
+}
+
+QPushButton:default {
+    border-color: #2f6fad;
+}
+
+/* --- menus and toolbars ------------------------------------------------- */
+
+QMenuBar {
+    background-color: #232428;
+}
+
+QMenuBar::item:selected {
+    background-color: #2f6fad;
+}
+
+QMenu {
+    background-color: #232428;
+    border: 1px solid #1b1c1f;
+}
+
+QMenu::item:selected {
+    background-color: #2f6fad;
+}
+
+QMenu::separator {
+    height: 1px;
+    background: #3a3d42;
+    margin: 3px 6px;
+}
+
+QToolBar {
+    background-color: #2b2d31;
+    border: none;
+    spacing: 2px;
+}
+
+/* --- item views --------------------------------------------------------- */
+
+QTableView, QTreeView, QListView {
+    background-color: #232428;
+    alternate-background-color: #2a2c30;
+    border: 1px solid #1b1c1f;
+    gridline-color: #3a3d42;
+}
+
+QHeaderView::section {
+    background-color: #2f3136;
+    border: none;
+    border-right: 1px solid #1b1c1f;
+    border-bottom: 1px solid #1b1c1f;
+    padding: 3px 6px;
+}
+
+QTableCornerButton::section {
+    background-color: #2f3136;
+}
+
+/* --- tabs --------------------------------------------------------------- */
+
+QTabWidget::pane {
+    border: 1px solid #1b1c1f;
+}
+
+QTabBar::tab {
+    background: #2f3136;
+    border: 1px solid #1b1c1f;
+    padding: 4px 10px;
+}
+
+QTabBar::tab:selected {
+    background: #3a3d42;
+}
+
+/* --- scroll bars --------------------------------------------------------- */
+
+QScrollBar:vertical {
+    background: #232428;
+    width: 12px;
+    margin: 0;
+}
+
+QScrollBar:horizontal {
+    background: #232428;
+    height: 12px;
+    margin: 0;
+}
+
+QScrollBar::handle:vertical {
+    background: #44484f;
+    min-height: 24px;
+    border-radius: 5px;
+    margin: 2px;
+}
+
+QScrollBar::handle:horizontal {
+    background: #44484f;
+    min-width: 24px;
+    border-radius: 5px;
+    margin: 2px;
+}
+
+QScrollBar::handle:vertical:hover, QScrollBar::handle:horizontal:hover {
+    background: #52565e;
+}
+
+QScrollBar::add-line, QScrollBar::sub-line {
+    width: 0;
+    height: 0;
+}
+
+QScrollBar::add-page, QScrollBar::sub-page {
+    background: none;
+}
+
+/* --- checkable indicators ------------------------------------------------ */
+
+QCheckBox::indicator, QRadioButton::indicator {
+    width: 14px;
+    height: 14px;
+    border: 1px solid #46494f;
+    background-color: #232428;
+    border-radius: 3px;
+}
+
+QRadioButton::indicator {
+    border-radius: 7px;
+}
+
+QCheckBox::indicator:checked, QRadioButton::indicator:checked {
+    background-color: #2f6fad;
+    border-color: #2f6fad;
+}
+
+QCheckBox::indicator:indeterminate {
+    background-color: #56606c;
+}
+
+/* --- everything else ------------------------------------------------------ */
+
+QGroupBox {
+    border: 1px solid #3a3d42;
+    border-radius: 3px;
+    margin-top: 8px;
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 8px;
+    padding: 0 3px;
+}
+
+QSplitter::handle {
+    background-color: #1b1c1f;
+}
+
+QStatusBar {
+    background-color: #232428;
+}
+
+QStatusBar::item {
+    border: none;
+}
+
+QProgressBar {
+    background-color: #232428;
+    border: 1px solid #1b1c1f;
+    border-radius: 3px;
+    text-align: center;
+}
+
+QProgressBar::chunk {
+    background-color: #2f6fad;
+}
+
+QToolTip {
+    background-color: #232428;
+    color: #e6e8eb;
+    border: 1px solid #2f6fad;
+}

--- a/mint/gui/themes/light.qss
+++ b/mint/gui/themes/light.qss
@@ -1,0 +1,247 @@
+/* MINT light theme
+ * A flat, self-contained light look, independent of the desktop theme and of
+ * which Qt style plugins are installed on the host.
+ */
+
+QWidget {
+    background-color: #f2f3f5;
+    color: #1f2328;
+    selection-background-color: #2f6fad;
+    selection-color: #ffffff;
+}
+
+QWidget:disabled {
+    color: #9aa0a8;
+}
+
+/* --- text inputs ------------------------------------------------------- */
+
+QLineEdit, QTextEdit, QPlainTextEdit, QSpinBox, QDoubleSpinBox,
+QDateEdit, QTimeEdit, QDateTimeEdit, QComboBox {
+    background-color: #ffffff;
+    border: 1px solid #b6b9bf;
+    border-radius: 3px;
+    padding: 2px 4px;
+}
+
+QLineEdit:focus, QTextEdit:focus, QPlainTextEdit:focus, QSpinBox:focus,
+QDoubleSpinBox:focus, QDateEdit:focus, QTimeEdit:focus, QDateTimeEdit:focus,
+QComboBox:focus {
+    border: 1px solid #2f6fad;
+}
+
+QComboBox::drop-down {
+    border: none;
+    width: 18px;
+}
+
+QComboBox QAbstractItemView {
+    background-color: #ffffff;
+    border: 1px solid #b6b9bf;
+}
+
+/* --- buttons ----------------------------------------------------------- */
+
+QPushButton, QToolButton {
+    background-color: #e2e4e8;
+    border: 1px solid #b6b9bf;
+    border-radius: 3px;
+    padding: 3px 10px;
+}
+
+QToolButton {
+    padding: 3px;
+}
+
+QPushButton:hover, QToolButton:hover {
+    background-color: #d6d9de;
+}
+
+QPushButton:pressed, QToolButton:pressed, QToolButton:checked {
+    background-color: #c9ccd2;
+}
+
+QPushButton:disabled, QToolButton:disabled {
+    background-color: #e9eaee;
+}
+
+QPushButton:default {
+    border-color: #2f6fad;
+}
+
+/* --- menus and toolbars ------------------------------------------------- */
+
+QMenuBar {
+    background-color: #e9eaee;
+}
+
+QMenuBar::item:selected {
+    background-color: #2f6fad;
+    color: #ffffff;
+}
+
+QMenu {
+    background-color: #ffffff;
+    border: 1px solid #b6b9bf;
+}
+
+QMenu::item:selected {
+    background-color: #2f6fad;
+    color: #ffffff;
+}
+
+QMenu::separator {
+    height: 1px;
+    background: #d6d9de;
+    margin: 3px 6px;
+}
+
+QToolBar {
+    background-color: #f2f3f5;
+    border: none;
+    spacing: 2px;
+}
+
+/* --- item views --------------------------------------------------------- */
+
+QTableView, QTreeView, QListView {
+    background-color: #ffffff;
+    alternate-background-color: #f0f1f4;
+    border: 1px solid #b6b9bf;
+    gridline-color: #d6d9de;
+}
+
+QHeaderView::section {
+    background-color: #e9eaee;
+    border: none;
+    border-right: 1px solid #b6b9bf;
+    border-bottom: 1px solid #b6b9bf;
+    padding: 3px 6px;
+}
+
+QTableCornerButton::section {
+    background-color: #e9eaee;
+}
+
+/* --- tabs --------------------------------------------------------------- */
+
+QTabWidget::pane {
+    border: 1px solid #b6b9bf;
+}
+
+QTabBar::tab {
+    background: #e9eaee;
+    border: 1px solid #b6b9bf;
+    padding: 4px 10px;
+}
+
+QTabBar::tab:selected {
+    background: #ffffff;
+}
+
+/* --- scroll bars --------------------------------------------------------- */
+
+QScrollBar:vertical {
+    background: #e9eaee;
+    width: 12px;
+    margin: 0;
+}
+
+QScrollBar:horizontal {
+    background: #e9eaee;
+    height: 12px;
+    margin: 0;
+}
+
+QScrollBar::handle:vertical {
+    background: #c2c6cc;
+    min-height: 24px;
+    border-radius: 5px;
+    margin: 2px;
+}
+
+QScrollBar::handle:horizontal {
+    background: #c2c6cc;
+    min-width: 24px;
+    border-radius: 5px;
+    margin: 2px;
+}
+
+QScrollBar::handle:vertical:hover, QScrollBar::handle:horizontal:hover {
+    background: #aeb3ba;
+}
+
+QScrollBar::add-line, QScrollBar::sub-line {
+    width: 0;
+    height: 0;
+}
+
+QScrollBar::add-page, QScrollBar::sub-page {
+    background: none;
+}
+
+/* --- checkable indicators ------------------------------------------------ */
+
+QCheckBox::indicator, QRadioButton::indicator {
+    width: 14px;
+    height: 14px;
+    border: 1px solid #b6b9bf;
+    background-color: #ffffff;
+    border-radius: 3px;
+}
+
+QRadioButton::indicator {
+    border-radius: 7px;
+}
+
+QCheckBox::indicator:checked, QRadioButton::indicator:checked {
+    background-color: #2f6fad;
+    border-color: #2f6fad;
+}
+
+QCheckBox::indicator:indeterminate {
+    background-color: #9fb8d0;
+}
+
+/* --- everything else ------------------------------------------------------ */
+
+QGroupBox {
+    border: 1px solid #d6d9de;
+    border-radius: 3px;
+    margin-top: 8px;
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 8px;
+    padding: 0 3px;
+}
+
+QSplitter::handle {
+    background-color: #d6d9de;
+}
+
+QStatusBar {
+    background-color: #e9eaee;
+}
+
+QStatusBar::item {
+    border: none;
+}
+
+QProgressBar {
+    background-color: #ffffff;
+    border: 1px solid #b6b9bf;
+    border-radius: 3px;
+    text-align: center;
+}
+
+QProgressBar::chunk {
+    background-color: #2f6fad;
+}
+
+QToolTip {
+    background-color: #ffffff;
+    color: #1f2328;
+    border: 1px solid #2f6fad;
+}

--- a/mint/tests/test_22_appearance.py
+++ b/mint/tests/test_22_appearance.py
@@ -12,7 +12,7 @@ or write a real user configuration file.
 import tempfile
 import unittest
 
-from PySide6.QtCore import QSettings
+from PySide6.QtCore import QSettings, QStandardPaths
 from PySide6.QtWidgets import QApplication, QStyleFactory
 
 from mint.gui.mtAppearance import (MTAppearanceMenu, STYLE_KEY, THEME_KEY, THEME_NONE, THEMES,
@@ -25,6 +25,7 @@ class AppearanceTest(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.app = ensure_qapp()
         cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_format = QSettings.defaultFormat()
         QSettings.setDefaultFormat(QSettings.Format.IniFormat)
         QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, cls._tmp.name)
         cls._org, cls._name = cls.app.organizationName(), cls.app.applicationName()
@@ -35,6 +36,11 @@ class AppearanceTest(unittest.TestCase):
     def tearDownClass(cls) -> None:
         cls.app.setOrganizationName(cls._org)
         cls.app.setApplicationName(cls._name)
+        # restore the process-wide QSettings defaults changed in setUpClass (QSettings has
+        # no getter for the search path, so fall back to the platform config location)
+        QSettings.setDefaultFormat(cls._prev_format)
+        QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope,
+                          QStandardPaths.writableLocation(QStandardPaths.StandardLocation.GenericConfigLocation))
         cls._tmp.cleanup()
 
     def setUp(self):
@@ -81,6 +87,21 @@ class AppearanceTest(unittest.TestCase):
         restore_appearance()
         self.assertEqual(QApplication.instance().styleSheet(), '')
         self.assertEqual(QSettings().value(THEME_KEY), THEME_NONE)
+
+    def test_restore_appearance_resets_unknown_style(self):
+        before = QApplication.style().objectName()
+        QSettings().setValue(STYLE_KEY, 'no-such-style')
+        restore_appearance()
+        self.assertEqual(QApplication.style().objectName(), before)
+        self.assertIsNone(QSettings().value(STYLE_KEY))
+
+    def test_menu_normalizes_unknown_style(self):
+        style = QStyleFactory.keys()[0]
+        apply_style(style)
+        QSettings().setValue(STYLE_KEY, 'no-such-style')
+        menu = MTAppearanceMenu()
+        checked = [a.text() for a in menu.actions()[0].menu().actions() if a.isChecked()]
+        self.assertEqual(checked, [style])
 
     def test_menu_reflects_state_and_normalizes_unknown_theme(self):
         menu = MTAppearanceMenu()

--- a/mint/tests/test_22_appearance.py
+++ b/mint/tests/test_22_appearance.py
@@ -1,0 +1,113 @@
+"""Tests for the View > Appearance machinery (mint.gui.mtAppearance).
+
+Covers runtime switching of the widget style and the bundled QSS themes,
+persistence of both choices via QSettings, their restoration in a fresh
+session (restore_appearance), normalization of legacy/unknown persisted
+values, and the menu actions actually driving the appearance.
+
+QSettings is redirected to a temporary directory so the tests never read
+or write a real user configuration file.
+"""
+
+import tempfile
+import unittest
+
+from PySide6.QtCore import QSettings
+from PySide6.QtWidgets import QApplication, QStyleFactory
+
+from mint.gui.mtAppearance import (MTAppearanceMenu, STYLE_KEY, THEME_KEY, THEME_NONE, THEMES,
+                                   apply_style, apply_theme, restore_appearance)
+from mint.tests.qAppSingleton import ensure_qapp
+
+
+class AppearanceTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.app = ensure_qapp()
+        cls._tmp = tempfile.TemporaryDirectory()
+        QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+        QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, cls._tmp.name)
+        cls._org, cls._name = cls.app.organizationName(), cls.app.applicationName()
+        cls.app.setOrganizationName("ITER-tests")
+        cls.app.setApplicationName("MINT-tests")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.app.setOrganizationName(cls._org)
+        cls.app.setApplicationName(cls._name)
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        QSettings().clear()
+        QApplication.instance().setStyleSheet('')
+
+    def _theme_actions(self, menu: MTAppearanceMenu):
+        return menu.actions()[-1].menu().actions()
+
+    def test_apply_style_switches_and_persists(self):
+        for name in QStyleFactory.keys():
+            apply_style(name)
+            self.assertEqual(QApplication.style().objectName().lower(), name.lower())
+            self.assertEqual(QSettings().value(STYLE_KEY), name)
+
+    def test_apply_unknown_style_is_rejected(self):
+        before = QApplication.style().objectName()
+        apply_style('no-such-style')
+        self.assertEqual(QApplication.style().objectName(), before)
+        self.assertIsNone(QSettings().value(STYLE_KEY))
+
+    def test_apply_theme_switches_and_persists(self):
+        for name in THEMES:
+            apply_theme(name)
+            self.assertIn(f'MINT {name.lower()} theme', QApplication.instance().styleSheet())
+            self.assertEqual(QSettings().value(THEME_KEY), name)
+        apply_theme(THEME_NONE)
+        self.assertEqual(QApplication.instance().styleSheet(), '')
+        self.assertEqual(QSettings().value(THEME_KEY), THEME_NONE)
+
+    def test_restore_appearance_reapplies_persisted_choices(self):
+        style = QStyleFactory.keys()[-1]
+        QSettings().setValue(STYLE_KEY, style)
+        restore_appearance()
+        self.assertEqual(QApplication.style().objectName().lower(), style.lower())
+        # with a theme active QApplication.style() becomes an anonymous QStyleSheetStyle
+        # wrapper, so the style name can no longer be asserted alongside
+        QSettings().setValue(THEME_KEY, 'Dark')
+        restore_appearance()
+        self.assertIn('MINT dark theme', QApplication.instance().styleSheet())
+
+    def test_restore_appearance_resets_unknown_theme(self):
+        QSettings().setValue(THEME_KEY, 'no-such-theme')
+        restore_appearance()
+        self.assertEqual(QApplication.instance().styleSheet(), '')
+        self.assertEqual(QSettings().value(THEME_KEY), THEME_NONE)
+
+    def test_menu_reflects_state_and_normalizes_unknown_theme(self):
+        menu = MTAppearanceMenu()
+        self.assertEqual([a.text() for a in menu.actions()], ['&Style', '&Theme'])
+        checked = [a.text() for a in self._theme_actions(menu) if a.isChecked()]
+        self.assertEqual(checked, [THEME_NONE])
+
+        QSettings().setValue(THEME_KEY, 'no-such-theme')
+        menu = MTAppearanceMenu()
+        checked = [a.text() for a in self._theme_actions(menu) if a.isChecked()]
+        self.assertEqual(checked, [THEME_NONE])
+
+    def test_menu_style_checkmark_survives_active_theme(self):
+        style = QStyleFactory.keys()[0]
+        apply_style(style)
+        apply_theme('Dark')
+        menu = MTAppearanceMenu()
+        checked = [a.text() for a in menu.actions()[0].menu().actions() if a.isChecked()]
+        self.assertEqual(checked, [style])
+
+    def test_menu_action_applies_theme(self):
+        menu = MTAppearanceMenu()
+        dark = next(a for a in self._theme_actions(menu) if a.text() == 'Dark')
+        dark.trigger()
+        self.assertIn('MINT dark theme', QApplication.instance().styleSheet())
+        self.assertEqual(QSettings().value(THEME_KEY), 'Dark')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ include = ["mint*"]
 
 [tool.setuptools.package-data]
 "mint.data" = ["scsv/*", "workspaces/*", "data_signals/*", "canvas_properties/*", "blueprint.json", "help/*.json", "help/*.html", "help/*.md", "help/images/*"]
-"mint.gui" = ["icons/*.png", "res/*.ui"]
+"mint.gui" = ["icons/*.png", "res/*.ui", "themes/*.qss"]
 "mint" = ["mydatasources.cfg"]
 
 [project.scripts]


### PR DESCRIPTION
Users previously had to fiddle with environment variables (`XDG_CURRENT_DESKTOP`, `QT_STYLE_OVERRIDE`) to change how MINT looks. Add a View > Appearance menu that offers the built-in Qt widget styles and, on Qt >= 6.8, a system/light/dark color scheme choice. Both take effect immediately and are persisted with `QSettings`, then re-applied at startup right after the `QApplication` is created.

Note: an earlier revision offered a system/light/dark color-scheme selector via `QStyleHints.setColorScheme()`. It was dropped because Qt 6.9.3's GTK3 platform theme reports the requested scheme inverted and only serves dark palette variants (and without a platform theme the call is a no-op), so the control appeared flipped or dead. The bundled Dark/Light QSS themes cover that use case deterministically instead.