### PR TITLE
Raise default canvas 'Time range difference (s)' to 3600 s

### DIFF
--- a/mint/data/canvas_properties/default_properties.json
+++ b/mint/data/canvas_properties/default_properties.json
@@ -2,7 +2,7 @@
   "title": null,
   "font_size": 8,
   "shared_x_axis": true,
-  "max_diff": 1,
+  "max_diff": 3600,
   "round_hour": false,
   "log_scale": false,
   "grid": true,


### PR DESCRIPTION
Match the new iplotlib default for max_diff: tolerate up to one hour of time-range difference before warning and before splitting plots out of the shared-time group (#120).