### PR TITLE
add support for autoscale when exporting to an image

### DIFF
--- a/mint/app/createApp.py
+++ b/mint/app/createApp.py
@@ -31,6 +31,10 @@ def create_app(argv=None) -> (QApplication, Namespace):
                         type=int, default=1080, help='Exported image height')
     parser.add_argument('--ed', dest='export_dpi', metavar='export_dpi',
                         type=int, default=100, help='Exported image DPI')
+    parser.add_argument('--ea', '--export-autoscale', dest='export_autoscale', action='store_true', default=False,
+                        help='Force an "Autoscale All" on the Y axes of the exported image '
+                             '(instead of keeping the Y limits saved in the workspace). '
+                             'Only used together with -e; has no effect otherwise.')
     parser.add_argument('--version', action='version',
                         version=f"{parser.prog} - {get_versions()['version']}")
     args = parser.parse_args()

--- a/mint/app/entryPoint.py
+++ b/mint/app/entryPoint.py
@@ -126,7 +126,8 @@ def run_app(q_app: QApplication, args=None):
 
         if args.image_file:
             export_to_file(canvas_impl, main_win.canvas, args.image_file, dpi=args.export_dpi,
-                           width=args.export_width, height=args.export_height)
+                           width=args.export_width, height=args.export_height,
+                           autoscale=args.export_autoscale)
             exit(0)
 
     main_win.show()


### PR DESCRIPTION
lightweight fix (thanks Claude) to allow autoscale to ease report generation