### PR TITLE
feat(canvas): set the data range from the visible zoom (#107)

### DIFF
--- a/mint/gui/mtDataRangeSelector.py
+++ b/mint/gui/mtDataRangeSelector.py
@@ -72,6 +72,14 @@ class MTDataRangeSelector(QWidget):
         item = self.accessModes[self.stack.currentIndex()]
         return item.to_dict()
 
+    def force_apply_canvas_range_ns(self, start_ns: int, end_ns: int) -> None:
+        self.accessModes[0].set_from_ns(start_ns, end_ns)
+        if self.stack.currentIndex() != 0:
+            self.radioGroup.layout().itemAt(0).widget().click()
+
+    def apply_canvas_range_pulse_seconds(self, start_sec: float, end_sec: float) -> None:
+        self.accessModes[1].set_from_pulse_seconds(start_sec, end_sec)
+
     def import_dict(self, input_dict: dict):
         # older versions of MINT did not set the appropriate mode in the workspace.
         # for ex: even if pulse numbers were specified, the 'mode' key was set to TIME_RANGE.
@@ -102,6 +110,9 @@ class MTDataRangeSelector(QWidget):
     def is_x_axis_date(self) -> bool:
         mode = self.accessModes[self.stack.currentIndex()].mode
         return mode in [MTGenericAccessMode.TIME_RANGE, MTGenericAccessMode.RELATIVE_TIME]
+
+    def is_x_axis_pulse_relative(self) -> bool:
+        return self.accessModes[self.stack.currentIndex()].mode == MTGenericAccessMode.PULSE_NUMBER
 
     def get_pulse_number(self) -> List[str]:
         """Extracts pulse numbers if present in time_model """

--- a/mint/gui/mtMainWindow.py
+++ b/mint/gui/mtMainWindow.py
@@ -39,6 +39,7 @@ from mint.gui.mtDataRangeSelector import MTDataRangeSelector
 from mint.gui.mtErrorCatalog import ErrorCatalog
 from mint.gui.mtMemoryMonitor import MTMemoryMonitor
 from mint.gui.mtStatusBar import MTStatusBar
+from mint.gui.plotRange import read_x_range_ns, read_x_range_pulse_seconds
 from mint.gui.mtStreamConfigurator import MTStreamConfigurator
 from mint.gui.mtSignalConfigurator import MTSignalConfigurator
 from mint.gui.mtExportConfigurator import MTExportConfigurator
@@ -257,6 +258,7 @@ class MTMainWindow(ShiftHandlerMixin, IplotQtMainWindow):
         self.exportCfgWidget.exportStarted.connect(self.on_export_started)
         self.exportCfgWidget.ui.browseExport.connect(self.export_file)
         self.dataRangeSelector.cancelRefresh.connect(self.stop_auto_refresh)
+        self._install_set_time_window()
         self._install_help_anchors()
         self.resize(1920, 1080)
 
@@ -273,6 +275,36 @@ class MTMainWindow(ShiftHandlerMixin, IplotQtMainWindow):
         for widget, anchor in anchors.items():
             if widget is not None:
                 widget.setProperty(HELP_ANCHOR_PROPERTY, anchor)
+
+    def _install_set_time_window(self):
+        # Inject Set as Time Window into the backend's native plot context menu.
+        parser = self.canvasStack.currentWidget()._parser
+        parser.context_menu_extender = self._extend_plot_context_menu
+
+    def _extend_plot_context_menu(self, menu, plot=None):
+        # `plot` is the core Plot under the right-click (passed by the backend
+        # canvas). Acting on it — not the whole canvas — is what makes this
+        # per-plot (#107). Falls back to the first plot when absent.
+        x_is_time = self.dataRangeSelector.is_x_axis_date()
+        x_is_pulse = self.dataRangeSelector.is_x_axis_pulse_relative()
+        menu.addSeparator()
+        set_window = menu.addAction("Set as time window")
+        set_window.setEnabled(x_is_time or x_is_pulse)
+        set_window.triggered.connect(lambda: self.on_set_time_window(plot))
+
+    def on_set_time_window(self, plot=None):
+        parser = self.canvasStack.currentWidget()._parser
+        if self.dataRangeSelector.is_x_axis_pulse_relative():
+            x_range = read_x_range_pulse_seconds(self.canvas, parser, plot)
+            if x_range is None:
+                return
+            self.dataRangeSelector.apply_canvas_range_pulse_seconds(*x_range)
+            return
+        x_range = read_x_range_ns(self.canvas, parser, plot)
+        if x_range is None:
+            return
+        start_ns, end_ns = x_range
+        self.dataRangeSelector.force_apply_canvas_range_ns(start_ns, end_ns)
 
     def wire_connections(self):
         super().wire_connections()

--- a/mint/gui/plotRange.py
+++ b/mint/gui/plotRange.py
@@ -1,0 +1,112 @@
+"""Read the visible x-range of the active plot, in nanoseconds since epoch."""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+NS_PER_DAY = 86_400 * 1_000_000_000
+
+
+def _first_plot(canvas) -> Optional[object]:
+    plots_grid = getattr(canvas, "plots", None)
+    if not plots_grid:
+        return None
+    for col in plots_grid:
+        if not col:
+            continue
+        for plot in col:
+            if plot is not None:
+                return plot
+    return None
+
+
+def _impl_plot_for(parser, plot) -> Optional[object]:
+    lut = getattr(parser, "_plot_impl_plot_lut", None)
+    if not lut:
+        return None
+    impls = lut.get(id(plot))
+    if not impls:
+        return None
+    return impls[0]
+
+
+def _is_date_axis(plot) -> bool:
+    try:
+        return bool(plot.axes[0].is_date)
+    except (AttributeError, IndexError, TypeError):
+        return False
+
+
+def _matplotlib_view_to_ns(value: float, impl_plot) -> int:
+    formatter = getattr(impl_plot.xaxis, "get_major_formatter", None)
+    offset_ns = 0
+    if callable(formatter):
+        offset_ns = getattr(formatter(), "offset_ns", 0) or 0
+    if offset_ns == 100_000:
+        return int(value * 100_000)
+    if offset_ns > 0:
+        return int(value + offset_ns)
+    return int(value * NS_PER_DAY)
+
+
+def _pyqtgraph_view_to_ns(value: float, impl_plot) -> int:
+    try:
+        axis = impl_plot.getAxis('bottom')
+    except Exception:
+        return int(value)
+    real = getattr(axis, 'get_real_value', None)
+    if callable(real):
+        try:
+            return int(real(value))
+        except Exception:
+            pass
+    offset_ns = getattr(axis, 'offset', 0) or 0
+    if offset_ns == 100_000:
+        return int(value * 100_000)
+    return int(value + offset_ns)
+
+
+def read_x_range_ns(canvas, parser, plot=None) -> Optional[Tuple[int, int]]:
+    """Return (start_ns, end_ns) for ``plot`` (the plot under the right-click),
+    or the first plot when the caller passes none. None if unavailable."""
+    if plot is None:
+        plot = _first_plot(canvas)
+    if plot is None:
+        return None
+    if not _is_date_axis(plot):
+        return None
+    impl_plot = _impl_plot_for(parser, plot)
+    if impl_plot is None:
+        return None
+    try:
+        x_min, x_max = parser.get_impl_x_axis_limits(impl_plot)
+    except Exception:
+        return None
+    if x_min is None or x_max is None:
+        return None
+    backend = parser.__class__.__name__.lower()
+    if "matplotlib" in backend:
+        return _matplotlib_view_to_ns(x_min, impl_plot), _matplotlib_view_to_ns(x_max, impl_plot)
+    if "pyqtgraph" in backend:
+        return _pyqtgraph_view_to_ns(x_min, impl_plot), _pyqtgraph_view_to_ns(x_max, impl_plot)
+    return int(x_min), int(x_max)
+
+
+def read_x_range_pulse_seconds(canvas, parser, plot=None) -> Optional[Tuple[float, float]]:
+    """Return (start_sec, end_sec) for ``plot`` (the plot under the right-click)
+    in PULSE mode, or the first plot when the caller passes none."""
+    if plot is None:
+        plot = _first_plot(canvas)
+    if plot is None:
+        return None
+    if _is_date_axis(plot):
+        return None
+    impl_plot = _impl_plot_for(parser, plot)
+    if impl_plot is None:
+        return None
+    try:
+        x_min, x_max = parser.get_impl_x_axis_limits(impl_plot)
+    except Exception:
+        return None
+    if x_min is None or x_max is None:
+        return None
+    return float(x_min), float(x_max)

--- a/mint/models/accessModes/mtAbsoluteTime.py
+++ b/mint/models/accessModes/mtAbsoluteTime.py
@@ -128,6 +128,35 @@ class MTAbsoluteTime(MTGenericAccessMode):
         self.toTime.setStyleSheet(style)
         self.fromTime.setStyleSheet(style)
 
+    def set_from_ns(self, start_ns: int, end_ns: int) -> None:
+        for w, ns in ((self.fromTime, int(start_ns)), (self.toTime, int(end_ns))):
+            qdt_utc = QDateTime.fromMSecsSinceEpoch(ns // 1_000_000, Qt.UTC)
+            qdt_wall = QDateTime(qdt_utc.date(), qdt_utc.time())
+            w.blockSignals(True)
+            w.setDateTime(qdt_wall)
+            w.blockSignals(False)
+        ns_start = int(start_ns) % 1_000_000_000
+        ns_end = int(end_ns) % 1_000_000_000
+        self.fromTimeNs.blockSignals(True)
+        self.fromTimeNs.setText(str(ns_start).zfill(9))
+        self.fromTimeNs.blockSignals(False)
+        self.toTimeNs.blockSignals(True)
+        self.toTimeNs.setText(str(ns_end).zfill(9))
+        self.toTimeNs.blockSignals(False)
+        # Keep the backing model in sync with the widgets: properties() and
+        # get_time_range() read the range from the model, so "Set as time window"
+        # only takes effect on draw/export once the model is updated too — same
+        # pattern as fill_from_pulse. Without this the widgets show the zoom
+        # range but the plot/export keep the previous one (#107 / IDV-756).
+        self.model.setStringList([
+            self.fromTime.dateTime().toString(MTAbsoluteTime.TIME_FORMAT),
+            self.toTime.dateTime().toString(MTAbsoluteTime.TIME_FORMAT),
+            self.fromTimeNs.text(),
+            self.toTimeNs.text(),
+        ])
+        self.mapper.toFirst()
+        self.handle_time_validation()
+
     def from_dict(self, contents: dict):
         self.mapper.model().setStringList([contents.get("ts_start"),
                                            contents.get("ts_end"),

--- a/mint/models/accessModes/mtPulseId.py
+++ b/mint/models/accessModes/mtPulseId.py
@@ -1,6 +1,8 @@
 # Description: Implements a data access mode with pulse id's.
 # Author: Jaswant Sai Panchumarti
 
+import math
+
 from PySide6.QtWidgets import QComboBox, QLabel, QLineEdit, QPushButton, QHBoxLayout, QVBoxLayout, QFormLayout
 from PySide6.QtCore import QStringListModel, Qt
 from PySide6.QtGui import QDoubleValidator
@@ -90,14 +92,42 @@ class MTPulseId(MTGenericAccessMode):
         self.startTime.setStyleSheet(style)
         self.endTime.setStyleSheet(style)
 
+    def set_from_pulse_seconds(self, start_sec: float, end_sec: float) -> None:
+        base = self.options[self.units.currentIndex()][0]
+        self.model.setStringList([
+            self.pulseNumber.text(),
+            self.units.currentText(),
+            self._format_pulse_time(start_sec / base),
+            self._format_pulse_time(end_sec / base),
+        ])
+        self.mapper.toFirst()
+
+    @staticmethod
+    def _format_pulse_time(value: float) -> str:
+        if not math.isfinite(value):
+            return "0"
+        if value == int(value):
+            return str(int(value))
+        return f"{value:.6g}"
+
     def from_dict(self, contents: dict):
+        unit_label = self._unit_label_from_base(contents.get("base"))
         self.mapper.model().setStringList(
             [",".join(contents.get("pulse_nb") or []),
-             contents.get("base") or 'Seconds',
+             unit_label,
              contents.get("t_start") or '',
              contents.get("t_end") or '']
         )
+        idx = self.units.findText(unit_label)
+        if idx >= 0:
+            self.units.setCurrentIndex(idx)
         super().from_dict(contents)
+
+    def _unit_label_from_base(self, base) -> str:
+        for multiplier, label in self.options:
+            if multiplier == base or str(multiplier) == str(base) or label == base:
+                return label
+        return self.options[0][1]
 
     def on_search_pulse(self):
         self.selectPulseDialog.flag = "pulse_id"

--- a/mint/tests/test_22_set_time_window.py
+++ b/mint/tests/test_22_set_time_window.py
@@ -1,0 +1,367 @@
+"""Tests for Set as Time Window: plot-range helper conversion, the access
+mode range setters and the plot context-menu extender."""
+import unittest
+import unittest.mock
+from unittest.mock import MagicMock
+
+from iplotDataAccess.appDataAccess import AppDataAccess
+
+from mint.gui import plotRange
+from mint.tests.fixtures import write_csv_datasource_config
+from mint.tests.qAppSingleton import ensure_qapp
+
+
+def _ensure_data_access() -> None:
+    # MTPulseId (built unconditionally by MTDataRangeSelector) eventually
+    # touches AppDataAccess.da.default_ds via PulseTable. Same idempotent
+    # CSV bootstrap used by the rest of the suite.
+    if AppDataAccess.da is None:
+        AppDataAccess.initialize(write_csv_datasource_config())
+
+
+class PlotRangeHelperTests(unittest.TestCase):
+    def _fake_canvas_with_plot(self, plot):
+        canvas = MagicMock()
+        canvas.plots = [[plot]]
+        return canvas
+
+    def test_returns_none_when_no_plots(self):
+        canvas = MagicMock()
+        canvas.plots = []
+        self.assertIsNone(plotRange.read_x_range_ns(canvas, MagicMock()))
+
+    def test_returns_none_when_parser_has_no_lut_entry(self):
+        plot = MagicMock()
+        plot.axes = [MagicMock(is_date=False)]
+        canvas = self._fake_canvas_with_plot(plot)
+        parser = MagicMock()
+        parser._plot_impl_plot_lut = {}
+        self.assertIsNone(plotRange.read_x_range_ns(canvas, parser))
+
+    def test_pyqtgraph_view_to_ns_uses_axis_offset(self):
+        plot = MagicMock()
+        plot.axes = [MagicMock(is_date=True)]
+        axis = MagicMock(spec=['offset'])
+        axis.offset = 1_000_000_000_000
+        impl_plot = MagicMock()
+        impl_plot.getAxis = MagicMock(return_value=axis)
+        canvas = self._fake_canvas_with_plot(plot)
+        parser = MagicMock()
+        parser.__class__ = type("PyQtGraphParser", (object,), {})
+        parser._plot_impl_plot_lut = {id(plot): [impl_plot]}
+        parser.get_impl_x_axis_limits = MagicMock(return_value=(13.0, 713.0))
+        result = plotRange.read_x_range_ns(canvas, parser)
+        self.assertEqual(result, (1_000_000_000_013, 1_000_000_000_713))
+
+    def test_pyqtgraph_view_to_ns_prefers_get_real_value(self):
+        plot = MagicMock()
+        plot.axes = [MagicMock(is_date=True)]
+        axis = MagicMock()
+        axis.get_real_value = MagicMock(side_effect=lambda v: 1_000_000_000 + int(v))
+        impl_plot = MagicMock()
+        impl_plot.getAxis = MagicMock(return_value=axis)
+        canvas = self._fake_canvas_with_plot(plot)
+        parser = MagicMock()
+        parser.__class__ = type("PyQtGraphParser", (object,), {})
+        parser._plot_impl_plot_lut = {id(plot): [impl_plot]}
+        parser.get_impl_x_axis_limits = MagicMock(return_value=(10.0, 20.0))
+        result = plotRange.read_x_range_ns(canvas, parser)
+        self.assertEqual(result, (1_000_000_010, 1_000_000_020))
+
+    def test_matplotlib_days_to_ns_no_offset(self):
+        plot = MagicMock()
+        plot.axes = [MagicMock(is_date=True)]
+        impl_plot = MagicMock()
+        impl_plot.xaxis.get_major_formatter = MagicMock(
+            return_value=MagicMock(offset_ns=0))
+        canvas = self._fake_canvas_with_plot(plot)
+        parser = MagicMock()
+        parser.__class__ = type("MatplotlibParser", (object,), {})
+        parser._plot_impl_plot_lut = {id(plot): [impl_plot]}
+        # 19000 days since epoch → 19000 * 86400 * 1e9 ns
+        parser.get_impl_x_axis_limits = MagicMock(return_value=(19000.0, 19000.5))
+        result = plotRange.read_x_range_ns(canvas, parser)
+        expected_start = int(19000.0 * 86_400 * 1_000_000_000)
+        expected_end = int(19000.5 * 86_400 * 1_000_000_000)
+        self.assertEqual(result, (expected_start, expected_end))
+
+    def test_non_date_axis_rejected_by_read_x_range_ns(self):
+        plot = MagicMock()
+        plot.axes = [MagicMock(is_date=False)]
+        impl_plot = MagicMock()
+        canvas = self._fake_canvas_with_plot(plot)
+        parser = MagicMock()
+        parser.__class__ = type("MatplotlibParser", (object,), {})
+        parser._plot_impl_plot_lut = {id(plot): [impl_plot]}
+        parser.get_impl_x_axis_limits = MagicMock(return_value=(0.0, 659.6))
+        self.assertIsNone(plotRange.read_x_range_ns(canvas, parser))
+
+    def test_date_axis_rejected_by_read_x_range_pulse_seconds(self):
+        plot = MagicMock()
+        plot.axes = [MagicMock(is_date=True)]
+        impl_plot = MagicMock()
+        canvas = self._fake_canvas_with_plot(plot)
+        parser = MagicMock()
+        parser._plot_impl_plot_lut = {id(plot): [impl_plot]}
+        parser.get_impl_x_axis_limits = MagicMock(return_value=(19000.0, 19000.5))
+        self.assertIsNone(plotRange.read_x_range_pulse_seconds(canvas, parser))
+
+    def test_pulse_seconds_returns_raw_floats(self):
+        plot = MagicMock()
+        plot.axes = [MagicMock(is_date=False)]
+        impl_plot = MagicMock()
+        canvas = self._fake_canvas_with_plot(plot)
+        parser = MagicMock()
+        parser._plot_impl_plot_lut = {id(plot): [impl_plot]}
+        parser.get_impl_x_axis_limits = MagicMock(return_value=(120.5, 480.25))
+        result = plotRange.read_x_range_pulse_seconds(canvas, parser)
+        self.assertEqual(result, (120.5, 480.25))
+
+    def test_pulse_seconds_returns_none_when_no_plots(self):
+        canvas = MagicMock()
+        canvas.plots = []
+        self.assertIsNone(
+            plotRange.read_x_range_pulse_seconds(canvas, MagicMock()))
+
+
+class SetTimeWindowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = ensure_qapp()
+        _ensure_data_access()
+
+    def test_force_apply_switches_from_pulse_to_time_range(self):
+        from mint.gui.mtDataRangeSelector import MTDataRangeSelector
+        from mint.models import MTGenericAccessMode
+
+        selector = MTDataRangeSelector({"mode": MTGenericAccessMode.TIME_RANGE})
+        try:
+            selector.stack.setCurrentIndex(1)
+            selector.force_apply_canvas_range_ns(
+                1_641_760_133_123_456_789, 1_641_760_833_123_456_789)
+            self.assertEqual(selector.stack.currentIndex(), 0)
+            abs_mode = selector.accessModes[0]
+            self.assertEqual(abs_mode.fromTimeNs.text(), "123456789")
+            self.assertEqual(abs_mode.toTimeNs.text(), "123456789")
+        finally:
+            selector.deleteLater()
+
+    def test_force_apply_when_already_in_time_range(self):
+        from mint.gui.mtDataRangeSelector import MTDataRangeSelector
+        from mint.models import MTGenericAccessMode
+
+        selector = MTDataRangeSelector({"mode": MTGenericAccessMode.TIME_RANGE})
+        try:
+            self.assertEqual(selector.stack.currentIndex(), 0)
+            selector.force_apply_canvas_range_ns(
+                1_641_760_133_123_456_789, 1_641_760_833_123_456_789)
+            self.assertEqual(selector.stack.currentIndex(), 0)
+        finally:
+            selector.deleteLater()
+
+    def test_force_apply_syncs_model_for_draw_and_export(self):
+        # Regression (#107 / IDV-756): set_from_ns must push the zoom range
+        # into the backing model, not just the widgets. properties() — and
+        # through it get_time_range(), consumed by draw/export/save — reads
+        # from the model, so without the sync "Set as time window" would leave
+        # the plot on the previous range even though the fields show the new one.
+        from mint.gui.mtDataRangeSelector import MTDataRangeSelector
+        from mint.models import MTGenericAccessMode
+
+        selector = MTDataRangeSelector({"mode": MTGenericAccessMode.TIME_RANGE})
+        try:
+            selector.force_apply_canvas_range_ns(
+                1_641_760_133_123_456_789, 1_641_760_833_123_456_789)
+            props = selector.accessModes[0].properties()
+            # 1_641_760_133.123456789 s → 2022-01-09T20:28:53 UTC (+123456789 ns);
+            # 1_641_760_833.123456789 s → 2022-01-09T20:40:33 UTC.
+            self.assertEqual(props["ts_start"], "2022-01-09T20:28:53")
+            self.assertEqual(props["ts_end"], "2022-01-09T20:40:33")
+            self.assertEqual(props["ts_ns_start"], "123456789")
+            self.assertEqual(props["ts_ns_end"], "123456789")
+        finally:
+            selector.deleteLater()
+
+    def test_apply_pulse_seconds_respects_unit_and_keeps_mode(self):
+        from mint.gui.mtDataRangeSelector import MTDataRangeSelector
+        from mint.models import MTGenericAccessMode
+
+        selector = MTDataRangeSelector({"mode": MTGenericAccessMode.PULSE_NUMBER})
+        try:
+            pulse_mode = selector.accessModes[1]
+            pulse_mode.units.setCurrentIndex(1)
+            pulse_idx = selector.stack.currentIndex()
+            selector.apply_canvas_range_pulse_seconds(120.0, 480.0)
+            self.assertEqual(selector.stack.currentIndex(), pulse_idx)
+            self.assertEqual(pulse_mode.startTime.text(), "2")
+            self.assertEqual(pulse_mode.endTime.text(), "8")
+            self.assertEqual(pulse_mode.units.currentText(), "Minute(s)")
+            props = pulse_mode.properties()
+            self.assertEqual(props["t_start"], "2")
+            self.assertEqual(props["t_end"], "8")
+            self.assertEqual(props["base"], 60)
+        finally:
+            selector.deleteLater()
+
+    def test_apply_pulse_seconds_seconds_unit_passthrough(self):
+        from mint.gui.mtDataRangeSelector import MTDataRangeSelector
+        from mint.models import MTGenericAccessMode
+
+        selector = MTDataRangeSelector({"mode": MTGenericAccessMode.PULSE_NUMBER})
+        try:
+            pulse_mode = selector.accessModes[1]
+            pulse_mode.units.setCurrentIndex(0)
+            selector.apply_canvas_range_pulse_seconds(123.456, 789.0)
+            self.assertEqual(pulse_mode.startTime.text(), "123.456")
+            self.assertEqual(pulse_mode.endTime.text(), "789")
+            props = pulse_mode.properties()
+            self.assertEqual(props["t_start"], "123.456")
+            self.assertEqual(props["t_end"], "789")
+        finally:
+            selector.deleteLater()
+
+    def test_apply_pulse_seconds_preserves_pulse_number(self):
+        from mint.gui.mtDataRangeSelector import MTDataRangeSelector
+        from mint.models import MTGenericAccessMode
+
+        selector = MTDataRangeSelector({"mode": MTGenericAccessMode.PULSE_NUMBER})
+        try:
+            pulse_mode = selector.accessModes[1]
+            pulse_mode.pulseNumber.setText("12345")
+            pulse_mode.units.setCurrentIndex(0)
+            selector.apply_canvas_range_pulse_seconds(1.0, 2.0)
+            self.assertEqual(pulse_mode.pulseNumber.text(), "12345")
+            self.assertEqual(pulse_mode.properties()["pulse_nb"], ["12345"])
+        finally:
+            selector.deleteLater()
+
+    def test_from_dict_restores_hour_unit_after_export(self):
+        from mint.gui.mtDataRangeSelector import MTDataRangeSelector
+        from mint.models import MTGenericAccessMode
+
+        selector = MTDataRangeSelector({"mode": MTGenericAccessMode.PULSE_NUMBER})
+        try:
+            pulse_mode = selector.accessModes[1]
+            pulse_mode.from_dict({
+                "pulse_nb": ["ITER:test/1"],
+                "base": 3600,
+                "t_start": "0.339317",
+                "t_end": "0.417859",
+            })
+            self.assertEqual(pulse_mode.units.currentText(), "Hour(s)")
+            self.assertEqual(pulse_mode.units.currentIndex(), 2)
+            props = pulse_mode.properties()
+            self.assertEqual(props["base"], 3600)
+            self.assertEqual(props["t_start"], "0.339317")
+            self.assertEqual(props["t_end"], "0.417859")
+        finally:
+            selector.deleteLater()
+
+    def test_from_dict_handles_minute_and_day_units(self):
+        from mint.gui.mtDataRangeSelector import MTDataRangeSelector
+        from mint.models import MTGenericAccessMode
+
+        selector = MTDataRangeSelector({"mode": MTGenericAccessMode.PULSE_NUMBER})
+        try:
+            pulse_mode = selector.accessModes[1]
+            pulse_mode.from_dict({"pulse_nb": [], "base": 60, "t_start": "1", "t_end": "2"})
+            self.assertEqual(pulse_mode.units.currentText(), "Minute(s)")
+            pulse_mode.from_dict({"pulse_nb": [], "base": 86400, "t_start": "1", "t_end": "2"})
+            self.assertEqual(pulse_mode.units.currentText(), "Day(s)")
+        finally:
+            selector.deleteLater()
+
+    def test_from_dict_falls_back_to_seconds_on_unknown_base(self):
+        from mint.gui.mtDataRangeSelector import MTDataRangeSelector
+        from mint.models import MTGenericAccessMode
+
+        selector = MTDataRangeSelector({"mode": MTGenericAccessMode.PULSE_NUMBER})
+        try:
+            pulse_mode = selector.accessModes[1]
+            pulse_mode.from_dict({"pulse_nb": [], "base": "garbage", "t_start": "", "t_end": ""})
+            self.assertEqual(pulse_mode.units.currentText(), "Second(s)")
+        finally:
+            selector.deleteLater()
+
+    def test_format_pulse_time_handles_non_finite_values(self):
+        from mint.models.accessModes.mtPulseId import MTPulseId
+        self.assertEqual(MTPulseId._format_pulse_time(float("inf")), "0")
+        self.assertEqual(MTPulseId._format_pulse_time(float("-inf")), "0")
+        self.assertEqual(MTPulseId._format_pulse_time(float("nan")), "0")
+        self.assertEqual(MTPulseId._format_pulse_time(0.0), "0")
+        self.assertEqual(MTPulseId._format_pulse_time(1.5), "1.5")
+        self.assertEqual(MTPulseId._format_pulse_time(-3.0), "-3")
+
+    def test_install_registers_context_menu_extender(self):
+        from mint.gui import mtMainWindow as mw_mod
+
+        fake_self = MagicMock()
+        mw_mod.MTMainWindow._install_set_time_window(fake_self)
+        parser = fake_self.canvasStack.currentWidget.return_value._parser
+        self.assertIs(parser.context_menu_extender,
+                      fake_self._extend_plot_context_menu)
+
+    def test_extender_disables_set_time_window_when_axis_not_date(self):
+        from mint.gui import mtMainWindow as mw_mod
+
+        fake_self = MagicMock()
+        fake_self.dataRangeSelector.is_x_axis_date.return_value = False
+        fake_self.dataRangeSelector.is_x_axis_pulse_relative.return_value = False
+        menu = MagicMock()
+        mw_mod.MTMainWindow._extend_plot_context_menu(fake_self, menu)
+        menu.addSeparator.assert_called_once()
+        self.assertEqual(menu.addAction.call_count, 1)
+        menu.addAction.return_value.setEnabled.assert_called_with(False)
+
+    def test_extender_enables_time_window_in_pulse_mode(self):
+        from mint.gui import mtMainWindow as mw_mod
+
+        fake_self = MagicMock()
+        fake_self.dataRangeSelector.is_x_axis_date.return_value = False
+        fake_self.dataRangeSelector.is_x_axis_pulse_relative.return_value = True
+        menu = MagicMock()
+        mw_mod.MTMainWindow._extend_plot_context_menu(fake_self, menu)
+        menu.addAction.return_value.setEnabled.assert_called_with(True)
+
+
+class CanvasAxisGatingTests(unittest.TestCase):
+    def _fake_self(self, *, is_date: bool):
+        fake_self = MagicMock()
+        fake_self.dataRangeSelector.is_x_axis_date.return_value = is_date
+        return fake_self
+
+    def test_set_time_window_noop_when_no_visible_range(self):
+        from mint.gui import mtMainWindow as mw_mod
+
+        fake_self = self._fake_self(is_date=True)
+        fake_self.dataRangeSelector.is_x_axis_pulse_relative.return_value = False
+        with unittest.mock.patch.object(mw_mod, "read_x_range_ns",
+                                        return_value=None):
+            mw_mod.MTMainWindow.on_set_time_window(fake_self)
+        fake_self.dataRangeSelector.force_apply_canvas_range_ns.assert_not_called()
+
+    def test_set_time_window_pulse_mode_routes_to_pulse_seconds(self):
+        from mint.gui import mtMainWindow as mw_mod
+
+        fake_self = self._fake_self(is_date=False)
+        fake_self.dataRangeSelector.is_x_axis_pulse_relative.return_value = True
+        with unittest.mock.patch.object(mw_mod, "read_x_range_pulse_seconds",
+                                        return_value=(120.0, 480.0)) as rpr:
+            mw_mod.MTMainWindow.on_set_time_window(fake_self)
+        rpr.assert_called_once()
+        fake_self.dataRangeSelector.apply_canvas_range_pulse_seconds.assert_called_once_with(120.0, 480.0)
+        fake_self.dataRangeSelector.force_apply_canvas_range_ns.assert_not_called()
+
+    def test_set_time_window_pulse_mode_noop_when_no_visible_range(self):
+        from mint.gui import mtMainWindow as mw_mod
+
+        fake_self = self._fake_self(is_date=False)
+        fake_self.dataRangeSelector.is_x_axis_pulse_relative.return_value = True
+        with unittest.mock.patch.object(mw_mod, "read_x_range_pulse_seconds",
+                                        return_value=None):
+            mw_mod.MTMainWindow.on_set_time_window(fake_self)
+        fake_self.dataRangeSelector.apply_canvas_range_pulse_seconds.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Right-click a plot and pick "Set as time window" to adopt its visible x-range as the data range. Absolute time forces a switch to TIME_RANGE; pulse-relative mode keeps the mode and converts to the selected unit. set_from_ns syncs the backing model so draw/export see the new range.