### PR TITLE
Turn the mini-map off when a stream starts (#154)

### DIFF
--- a/mint/data/help/manual.html
+++ b/mint/data/help/manual.html
@@ -249,7 +249,7 @@ $ mint
 <li><img src="image_14.png" class="inline-icon" alt="Create Pulse icon" /> <strong>Create Pulse</strong>: create a UDA pulse from the visible time range — set category, status and description; leave the number empty for automatic numbering. Shown only with a write-capable UDA server.</li>
 <li><img src="image_15.png" class="inline-icon" alt="Update Pulse icon" /> <strong>Update Pulse</strong>: search for an existing pulse and update its time range, status or description.</li>
 <li>Gears: open the preferences panel (canvas, plot, signal, axis levels).</li>
-<li><strong>MINI-MAP</strong>: toggle a small overview of the current plot below the canvas. Enabled only when a single PlotXY is visible — either a single-plot canvas or focus mode — and stays greyed out otherwise. The mini-map shows the same signal over the original time window captured at <em>Draw</em> time, with an orange overlay that tracks the zoomed / panned region of the main plot in real time. The toggle is persisted with the workspace (<code>show_minimap</code> flag).</li>
+<li><strong>MINI-MAP</strong>: toggle a small overview of the current plot below the canvas. Enabled only when a single PlotXY is visible — either a single-plot canvas or focus mode — and never while streaming; it stays greyed out otherwise. The mini-map shows the same signal over the original time window captured at <em>Draw</em> time, with an orange overlay that tracks the zoomed / panned region of the main plot in real time. The toggle is persisted with the workspace (<code>show_minimap</code> flag).</li>
 <li><strong>DETACH</strong> / <strong>REATTACH</strong>: float the canvas in its own window.</li>
 </ul>
 <p>Right-click a plot for per-plot actions:</p>
@@ -407,7 +407,7 @@ $ ls `echo $(dirname "$IPLOT_SOURCES_CONFIG")/data/workspaces`              # SD
 </li>
 <li><strong>Hide unused columns?</strong> Use <em>Hide/Show columns</em> above the table.</li>
 <li><strong>Drag-and-drop a signal across plots?</strong> Yes - in SELECT mode.</li>
-<li><strong>Why is the mini-map button greyed out?</strong> It is only available when a single PlotXY is visible — a single-plot canvas or focus mode.</li>
+<li><strong>Why is the mini-map button greyed out?</strong> It is only available when a single PlotXY is visible — a single-plot canvas or focus mode — and not while streaming.</li>
 </ol>
 <h2 id="errors">6. Error reference</h2>
 <p>MINT reports two kinds of feedback. <em>Validation messages</em> (e.g. <code>Invalid date format</code>, <code>Alias already in use</code>) are written to the log when you edit the table; they are self-explanatory and not duplicated here. <em>Conceptual errors</em> (network problems, mismatched signal shapes, permission issues) are the ones that benefit from extra context — those are catalogued below and are reachable from popups, the Status column tooltip and the Help menu.</p>

--- a/mint/data/help/manual.md
+++ b/mint/data/help/manual.md
@@ -182,7 +182,7 @@ Above the canvas sits a toolbar (movable when the canvas is detached). Buttons:
 - <img src="image_14.png" class="inline-icon" alt="Create Pulse icon" /> **Create Pulse**: create a UDA pulse from the visible time range — set category, status and description; leave the number empty for automatic numbering. Shown only with a write-capable UDA server.
 - <img src="image_15.png" class="inline-icon" alt="Update Pulse icon" /> **Update Pulse**: search for an existing pulse and update its time range, status or description.
 - Gears: open the preferences panel (canvas, plot, signal, axis levels).
-- **MINI-MAP**: toggle a small overview of the current plot below the canvas. Enabled only when a single PlotXY is visible — either a single-plot canvas or focus mode — and stays greyed out otherwise. The mini-map shows the same signal over the original time window captured at *Draw* time, with an orange overlay that tracks the zoomed / panned region of the main plot in real time. The toggle is persisted with the workspace (`show_minimap` flag).
+- **MINI-MAP**: toggle a small overview of the current plot below the canvas. Enabled only when a single PlotXY is visible — either a single-plot canvas or focus mode — and never while streaming; it stays greyed out otherwise. The mini-map shows the same signal over the original time window captured at *Draw* time, with an orange overlay that tracks the zoomed / panned region of the main plot in real time. The toggle is persisted with the workspace (`show_minimap` flag).
 - **DETACH** / **REATTACH**: float the canvas in its own window.
 
 Right-click a plot for per-plot actions:
@@ -355,7 +355,7 @@ This section is auto-generated from the code at build time. Do not edit by hand 
 18. **Cell too small to write an expression?** Right-click and pick *Editor mode*; the resulting window is resizable.
 19. **Hide unused columns?** Use *Hide/Show columns* above the table.
 20. **Drag-and-drop a signal across plots?** Yes - in SELECT mode.
-21. **Why is the mini-map button greyed out?** It is only available when a single PlotXY is visible — a single-plot canvas or focus mode.
+21. **Why is the mini-map button greyed out?** It is only available when a single PlotXY is visible — a single-plot canvas or focus mode — and not while streaming.
 
 ## 6. Error reference {#errors}
 

--- a/mint/gui/mtMainWindow.py
+++ b/mint/gui/mtMainWindow.py
@@ -1013,6 +1013,11 @@ class MTMainWindow(ShiftHandlerMixin, IplotQtMainWindow):
         finally:
             canvas_widget.setUpdatesEnabled(True)
 
+        # Streaming makes the mini-map ineligible, and the rebuild above does not
+        # go through the paths that keep the toolbar in sync. Do it here, before
+        # the stream starts feeding the canvas.
+        self.refresh_minimap_availability()
+
         self.streamerCfgWidget.streamer = CanvasStreamer(self.da)
         window_ns = self.streamerCfgWidget.time_window() * 1_000_000_000
         max_points = self.streamerCfgWidget.max_points()

--- a/mint/tests/test_20_stream_handlers.py
+++ b/mint/tests/test_20_stream_handlers.py
@@ -1,10 +1,15 @@
 """Tests for MTMainWindow stream handler wiring: Stream/Stop button text
-toggle."""
+toggle and mini-map availability."""
 
 import unittest
+from unittest import mock
 
+import numpy as np
 from iplotDataAccess.appDataAccess import AppDataAccess
 from iplotlib.core.canvas import Canvas
+from iplotlib.core.plot import PlotXY
+from iplotlib.core.signal import SignalXY
+from iplotlib.data_access.streamer import CanvasStreamer
 from iplotlib.interface.iplotSignalAdapter import AccessHelper
 
 from mint.gui.mtMainWindow import MTMainWindow
@@ -41,6 +46,38 @@ class StreamHandlersTest(unittest.TestCase):
             win.streamBtn.setText("Stop")
             win.on_stream_stopped()
             self.assertEqual(win.streamBtn.text(), "Stream")
+        finally:
+            win.close()
+
+    def test_on_stream_started_turns_the_minimap_off(self):
+        win = _build_main_window()
+        try:
+            plot = PlotXY()
+            signal = SignalXY(label='s')
+            signal.set_data([np.linspace(0, 1, 10), np.zeros(10)])
+            plot.add_signal(signal)
+            win.canvas.add_plot(plot, 0)
+            w = win.canvasStack.currentWidget()
+            w.set_canvas(win.canvas)
+            win.refresh_minimap_availability()
+            win.toolBar.minimapAction.setChecked(True)
+            self.app.processEvents()
+            self.assertTrue(win.canvas.show_minimap)
+
+            # Stand in for build(stream=True): the rebuild needs a populated
+            # signals table, and the only part of it that matters here is the
+            # streaming flag it raises on the canvas.
+            def fake_build(stream=False):
+                win.canvas.streaming = stream
+
+            with mock.patch.object(win, 'build', fake_build), \
+                    mock.patch.object(CanvasStreamer, 'start'):
+                win.on_stream_started()
+            self.app.processEvents()
+
+            self.assertFalse(win.toolBar.minimapAction.isEnabled())
+            self.assertFalse(win.toolBar.minimapAction.isChecked())
+            self.assertFalse(win.canvas.show_minimap)
         finally:
             win.close()
 

--- a/mint/tests/test_20_stream_handlers.py
+++ b/mint/tests/test_20_stream_handlers.py
@@ -24,6 +24,16 @@ def _ensure_data_access():
     return AppDataAccess.get_data_access()
 
 
+def _minimap_guards_streaming() -> bool:
+    """Whether the installed iplotlib already rejects a streaming canvas. The
+    guard ships in iplotlib and mint's CI installs it from develop, so the
+    integration test below runs only once that change reaches develop."""
+    probe = Canvas(1, 1)
+    probe.add_plot(PlotXY(), 0)
+    probe.streaming = True
+    return not probe.is_minimap_eligible()
+
+
 def _build_main_window(impl: str = 'matplotlib') -> MTMainWindow:
     canvas = Canvas()
     time_model = {"range": {}}
@@ -49,6 +59,8 @@ class StreamHandlersTest(unittest.TestCase):
         finally:
             win.close()
 
+    @unittest.skipUnless(_minimap_guards_streaming(),
+                         "installed iplotlib still allows the mini-map while streaming")
     def test_on_stream_started_turns_the_minimap_off(self):
         win = _build_main_window()
         try:


### PR DESCRIPTION
Companion to iplot-viz/iplotlib#63, which makes a streaming canvas ineligible for the mini-map. Addresses #154.

## Change

`on_stream_started()` rebuilds the canvas in streaming mode but does not go through the paths that keep the toolbar in sync, so the mini-map action stayed enabled and checked over a panel the backends had already hidden. The availability is now refreshed after the rebuild and before the streamer starts feeding the canvas.

The user manual entry and the FAQ were updated, and `manual.html` was regenerated locally so the embedded-manual check passes on the first run.

## Verification

- Full suite: 249 passed, 3 skipped with the iplotlib change in place; 248 passed, 4 skipped without it (the new test skips instead of failing).
- Removing the refresh call turns the new test red.

## Test gating

mint's CI installs iplotlib from develop, where a streaming canvas is still eligible, so the new integration test is gated on a probe of the installed iplotlib, the same way the Home button and ruler workspace tests are. Once iplotlib#63 reaches develop the CI should be re-run: the test will stop skipping and exercise the guard for real.

## Note for testing

After pressing Stop the mini-map stays greyed out until the next Draw, because `canvas.streaming` is only cleared by the next `build()`. Intentional: the data and the axis on screen are still the streaming ones.

Merge after iplotlib#63.