### PR TITLE
Require the 1.5.0 dependency stack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "iplotLogging >= 1.2.0",
-    "iplotlib >= 1.3.2",
-    "iplotDataAccess >= 1.3.1",
-    "iplotWidgets >= 1.3.0",
-    "iplotProcessing >= 1.1.5",
+    "iplotLogging >= 1.2.2",
+    "iplotlib >= 1.5.0",
+    "iplotDataAccess >= 1.5.0",
+    "iplotWidgets >= 1.5.0",
+    "iplotProcessing >= 1.2.1",
     "pandas >= 2.2.0",
     "psutil >= 5.8.0",
 ]


### PR DESCRIPTION
Merges the release/1.5.0 branch back into develop so the updated dependency pins are not left behind on the release branch.

Same commit that was tagged as 1.5.0.

Part of #164.